### PR TITLE
Update BillingConfiguration.java

### DIFF
--- a/dataflow-website/batch-developer-guides/batch/batchsamples/billrun/src/main/java/io/spring/billrun/configuration/BillingConfiguration.java
+++ b/dataflow-website/batch-developer-guides/batch/batchsamples/billrun/src/main/java/io/spring/billrun/configuration/BillingConfiguration.java
@@ -89,7 +89,7 @@ public class BillingConfiguration {
 	}
 
 	@Bean
-	public ItemWriter<Bill> jdbcBillWriter(DataSource dataSource) {
+	public JdbcBatchItemWriter<Bill> jdbcBillWriter(DataSource dataSource) {
 		JdbcBatchItemWriter<Bill> writer = new JdbcBatchItemWriterBuilder<Bill>()
 						.beanMapped()
 				.dataSource(dataSource)


### PR DESCRIPTION
Explicit return types should be consistent across both the reader and the writer.