### PR TITLE
Fix proposal for task arg parse url

### DIFF
--- a/dataflow-website/recipes/polyglot/polyglot-python-task/util/task_args.py
+++ b/dataflow-website/recipes/polyglot/polyglot-python-task/util/task_args.py
@@ -13,7 +13,7 @@ def get_cmd_arg(name):
       value of the requested argument.
     """
     d = defaultdict(list)
-    for k, v in ((k.lstrip('-'), v) for k, v in (a.split('=') for a in sys.argv[1:])):
+    for k, v in ((k.lstrip('-'), v) for k, v in (a.split('=', 1) for a in sys.argv[1:])):
         d[k].append(v)
 
     if bool(d[name]):


### PR DESCRIPTION
To fix I added ", 1" notation to `a.split('=', 1) for a in sys.argv[1:]` at line 16 of ./polyglot-python-task/util/task_args.py

Issue spring-cloud / spring-cloud-dataflow-samples #147