### PR TITLE
Add custom batch configurer for Oracle

### DIFF
--- a/timestamp-batch/src/main/java/io/spring/configuration/TimestampBatchTaskConfiguration.java
+++ b/timestamp-batch/src/main/java/io/spring/configuration/TimestampBatchTaskConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,20 +20,28 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import javax.sql.DataSource;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.batch.core.Job;
-import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
+import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @EnableConfigurationProperties({ TimestampBatchTaskProperties.class })
@@ -50,18 +58,46 @@ public class TimestampBatchTaskConfiguration {
 	@Autowired
 	private TimestampBatchTaskProperties config;
 
+	/**
+	 * Override default transaction isolation level 'ISOLATION_REPEATABLE_READ' which Oracle does not
+	 * support.
+	 */
+	@Configuration
+	@ConditionalOnProperty(value = "spring.datasource.driver", havingValue = "oracle.jdbc.OracleDriver")
+	static class OracleBatchConfig {
+		@Bean
+		BatchConfigurer oracleBatchConfigurer(DataSource dataSource) {
+			return new DefaultBatchConfigurer() {
+				@Override
+				public JobRepository getJobRepository() {
+					JobRepositoryFactoryBean factoryBean = new JobRepositoryFactoryBean();
+					factoryBean.setDatabaseType("ORACLE");
+					factoryBean.setDataSource(dataSource);
+					factoryBean.setTransactionManager(getTransactionManager());
+					factoryBean.setIsolationLevelForCreate("ISOLATION_READ_COMMITTED");
+					try {
+						return factoryBean.getObject();
+					}
+					catch (Exception e) {
+						throw new BeanCreationException(e.getMessage(), e);
+					}
+				}
+				@Override
+				public DataSourceTransactionManager getTransactionManager() {
+					return new DataSourceTransactionManager(dataSource);
+				}
+			};
+		}
+	}
+
 	@Bean
 	public Job job1() {
 		return jobBuilderFactory.get("job1")
 				.start(stepBuilderFactory.get("job1step1")
-						.tasklet(new Tasklet() {
-							@Override
-							public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
-									throws Exception {
-								DateFormat dateFormat = new SimpleDateFormat(config.getFormat());
-								logger.info(String.format("Job1 was run with date %s", dateFormat.format(new Date())));
-								return RepeatStatus.FINISHED;
-							}
+						.tasklet((contribution, chunkContext) -> {
+							DateFormat dateFormat = new SimpleDateFormat(config.getFormat());
+							logger.info(String.format("Job1 was run with date %s", dateFormat.format(new Date())));
+							return RepeatStatus.FINISHED;
 						})
 						.build())
 				.build();
@@ -71,14 +107,10 @@ public class TimestampBatchTaskConfiguration {
 	public Job job2() {
 		return jobBuilderFactory.get("job2")
 				.start(stepBuilderFactory.get("job2step1")
-						.tasklet(new Tasklet() {
-							@Override
-							public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
-									throws Exception {
-								DateFormat dateFormat = new SimpleDateFormat(config.getFormat());
-								logger.info(String.format("Job2 was run with date %s", dateFormat.format(new Date())));
-								return RepeatStatus.FINISHED;
-							}
+						.tasklet((contribution, chunkContext) -> {
+							DateFormat dateFormat = new SimpleDateFormat(config.getFormat());
+							logger.info(String.format("Job2 was run with date %s", dateFormat.format(new Date())));
+							return RepeatStatus.FINISHED;
 						})
 						.build())
 				.build();


### PR DESCRIPTION
Override default transaction isolation level 'ISOLATION_REPEATABLE_READ' which Oracle does not support.  This is required to run ATs against Oracle.