### PR TITLE
Correction for application argument format in README.adoc

### DIFF
--- a/dataflow-website/batch-developer-guides/batch/batchsamples/README.adoc
+++ b/dataflow-website/batch-developer-guides/batch/batchsamples/README.adoc
@@ -39,7 +39,7 @@ $ java -jar target/billsetuptask-2.0.0-SNAPSHOT.jar --spring.datasource.url=jdbc
 
 Assuming you are using Mariadb, this app will load data from the usageinfo.txt file found in the classpath (included in the jar).
 ```
-$ java -jar target/billrun-2.0.0-SNAPSHOT.jar --spring.datasource.url=--spring.datasource.url=jdbc:mariadb://localhost:3306/<your database>?useSSL=false --spring.datasource.username=<user> --spring.datasource.password=<password> --spring.datasource.driverClassName=org.mariadb.jdbc.Driver
+$ java -jar target/billrun-2.0.0-SNAPSHOT.jar --spring.datasource.url=jdbc:mariadb://localhost:3306/<your database>?useSSL=false --spring.datasource.username=<user> --spring.datasource.password=<password> --spring.datasource.driverClassName=org.mariadb.jdbc.Driver
 ```
 If you wish to read a directory containing the data you can use the following command line argument:
 `--usage.file.name=file://<location of json file to upload>`


### PR DESCRIPTION
- looks like `--spring.datasource.url=` was duplicated in README.adoc
<img width="940" alt="Screen Shot 2022-05-24 at 11 12 00 PM" src="https://user-images.githubusercontent.com/1542352/170194358-05e015a2-7027-40a3-a6ca-794cbeece323.png">

