### PR TITLE
Fix a typo on README.md

### DIFF
--- a/dataflow-website/stream-developer-guides/streams/standalone-stream-sample/README.md
+++ b/dataflow-website/stream-developer-guides/streams/standalone-stream-sample/README.md
@@ -10,7 +10,7 @@ $./mvnw clean package -Pkafka
 or
 
 ```bash
-$./mvnw clean package -Pkafka
+$./mvnw clean package -Prabbit
 ```
 
 ## Building Docker Images


### PR DESCRIPTION
This PR fixes a typo on the `mvnw`command line for rabbit package.