### PR TITLE
Updated Demo to resolve use of H2 by default

### DIFF
--- a/timestamp-batch-3.0.x/src/main/java/io/spring/configuration/TimestampBatchTaskConfiguration.java
+++ b/timestamp-batch-3.0.x/src/main/java/io/spring/configuration/TimestampBatchTaskConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -47,16 +48,24 @@ public class TimestampBatchTaskConfiguration extends DefaultBatchConfiguration {
 	private static final Log logger = LogFactory.getLog(TimestampBatchTaskProperties.class);
 
 
+	@Value("${spring.batch.jdbc.table-prefix:BATCH_}")
+	private String tablePrefix;
+
 	@Autowired
 	private TimestampBatchTaskProperties config;
 
 	@Bean
-	@ConditionalOnProperty(name = "spring.datasource.driver-class-name", matchIfMissing = true)
+	@ConditionalOnProperty(name = "spring.datasource.driver-class-name", matchIfMissing = true, havingValue="matchonlyifmissing")
 	public DataSource dataSource() {
 		return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
 				.addScript("/org/springframework/batch/core/schema-h2.sql")
 				.generateUniqueName(true).build();
 	}
+
+	protected String getTablePrefix() {
+		return tablePrefix;
+	}
+
 	/**
 	 * Override default transaction isolation level 'ISOLATION_REPEATABLE_READ' which Oracle does not
 	 * support.

--- a/timestamp-batch-3.0.x/src/test/java/io/spring/TimestampBatchTaskTests.java
+++ b/timestamp-batch-3.0.x/src/test/java/io/spring/TimestampBatchTaskTests.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Glenn Renfro
  */
 @ExtendWith(OutputCaptureExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "--timestamp.format=yyyy.......")
 public class TimestampBatchTaskTests {
 
 	@Test
@@ -43,12 +43,7 @@ public class TimestampBatchTaskTests {
 		final String UPDATE_TASK_MESSAGE = "Updating: TaskExecution with executionId=1 with the following";
 		final String JOB1_MESSAGE = "Job1 was run with date ";
 		final String JOB2_MESSAGE = "Job2 was run with date ";
-
-		String[] args = {"--timestamp.format=yyyy" + TEST_DATE_DOTS};
-
-		SpringApplication
-				.run(TestTimestampBatchTaskApplication.class, args);
-
+		
 		String output = capturedOutput.toString();
 
 		assertThat(output).contains(TEST_DATE_DOTS);
@@ -57,9 +52,7 @@ public class TimestampBatchTaskTests {
 
 		assertThat(output).contains(JOB1_MESSAGE);
 		assertThat(output).contains(JOB2_MESSAGE);
-
 	}
-
 
 	@SpringBootApplication
 	public static class TestTimestampBatchTaskApplication {


### PR DESCRIPTION
* Demo now uses the database specified.
* Only Creates H2 if user does not specify driverClassName
* Will use prefix that is specified by the spring.batch.jdbc.table-prefix property
* Updated test to remove duplicate launch.