### PR TITLE
Upgrade to baseimage version 3.9 (Bookworm),

### DIFF
--- a/dataflow-website/recipes/polyglot/polyglot-python-app/Dockerfile
+++ b/dataflow-website/recipes/polyglot/polyglot-python-app/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.7.3-slim
+FROM python:3.9.19-slim
 
 RUN pip install kafka-python
 RUN pip install flask
 
 ADD /util/* /util/
 ADD python_router_app.py /
+
 ENTRYPOINT ["python","/python_router_app.py"]
+
 CMD []

--- a/dataflow-website/recipes/polyglot/polyglot-python-task/Dockerfile
+++ b/dataflow-website/recipes/polyglot/polyglot-python-task/Dockerfile
@@ -1,10 +1,18 @@
-FROM python:3.7.3-slim
+FROM python:3.9.19-slim
+
 RUN apt-get update
-RUN apt-get install build-essential -y
-RUN apt-get install default-libmysqlclient-dev -y
+RUN apt-get install -y \
+        build-essential
+RUN apt-get install -y \
+        default-libmysqlclient-dev \
+        pkg-config
+
+RUN pip install --upgrade pip
 RUN pip install mysqlclient
 RUN pip install sqlalchemy
+
 ADD python_task.py /
 ADD util/* /util/
+
 ENTRYPOINT ["python","/python_task.py"]
 CMD []


### PR DESCRIPTION
as 3.7 (Stretch) is no longer buildable. 

In fact `apt-get update` fails on the task example, as the corresponding repositories are no longer available. So I've updated both examples.